### PR TITLE
Support correlation matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Changelog based on the [format here](https://keepachangelog.com/en/1.0.0/).
 
+## [2.1] - 29 March 2019
+
+### Added
+
+- Calculate the correlation matrix in the fit result. See: `ee94cb80e774c38848f31592b8df765c333fba7a`.
+- Read and write fit results with YAML, including integration tests. See:
+  `983a2519d9b882a34d6bf44be312b45a3e051316`.
+- Added test for invalid fit arguments. See: `009a974dc038d79ad2890e9c3f935094a88cb3ee`.
+
+### Changed
+
+- Modify the `ReactionPlaneFit.fit(...)` to return the minuit object for advanced use cases. The fit result
+  stores almost all of the minuit information, but it can be useful in limited circumstances. For now, it is
+  only used to check the correlation matrix calculation. See: `7a1efd908203abf1a1b8cb8d2f9d76afdfb1442d`.
+- Initialize the component fit functions when defining the fit objects. This allows fit components to be
+  evaluated using stored fit results. See: `e2673f25e7fa952087bb45ab5e35204850138b69`.
+- Updated typing information.  See: `0f284c79ccfb6ee04715b33e4500b2c96832f7ff` and
+  `60af85240d84adf5e011ee0b4b2f7a0c8cef154e`.
+- Updated documentation. See: `b94fc955ce15034490888ec75368853f61ad9244`.
+- Updated pre-commit hooks with newer versions of the packages. See:
+  `6d54231e4707502fec9811c0507daa5a37358076`.
+
 ## [2.0] - 22 February 2019
 
 Note the API changes introduced by moving the fit results to the components!

--- a/reaction_plane_fit/fit.py
+++ b/reaction_plane_fit/fit.py
@@ -226,7 +226,7 @@ class ReactionPlaneFit(ABC):
         minuit.print_matrix()
         return (minuit.migrad_ok(), minuit)
 
-    def fit(self, data: Union[InputData, Data], user_arguments: FitArguments = None) -> Tuple[bool, Data]:
+    def fit(self, data: Union[InputData, Data], user_arguments: FitArguments = None) -> Tuple[bool, Data, iminuit.Minuit]:
         """ Perform the actual fit.
 
         Args:
@@ -234,8 +234,11 @@ class ReactionPlaneFit(ABC):
                 ``[region][orientation]`` or ``[FitType]``. The values can be uproot or ROOT 1D histograms.
             user_arguments: User arguments to override the arguments to the fit. Default: None.
         Returns:
-            tuple: (fit_success, formatted_data) where fit_success (bool) is ``True`` if the fitting procedure was
-                successful, and formatted_data (dict) is the data reformatted in the preferred format for the fit.
+            tuple: (fit_success, formatted_data, minuit) where fit_success (bool) is ``True`` if the fitting
+                procedure was successful, formatted_data (dict) is the data reformatted in the preferred format for
+                the fit, and minuit (iminuit.Minuit) is the minuit object, which is provided it is provided for
+                specialized use cases. Note that the fit results (which contains most of the information in the minuit
+                object) are stored in the class.
         """
         # Validate settings.
         if user_arguments is None:
@@ -319,7 +322,7 @@ class ReactionPlaneFit(ABC):
             component.fit_result.errors = component.calculate_fit_errors(x = self.fit_result.x)
 
         # Return true to note success.
-        return (True, formatted_data)
+        return (True, formatted_data, minuit)
 
     def read_fit_results(self, filename: str, y: yaml.ruamel.yaml.YAML = None) -> bool:
         """ Read all fit results from the specified filename using YAML.

--- a/reaction_plane_fit/version.py
+++ b/reaction_plane_fit/version.py
@@ -12,7 +12,7 @@ as well as ``uproot`` (which more or less implements this pattern). Further disc
 import re
 
 # Provide the version as a string
-__version__ = "2.0"
+__version__ = "2.1"
 version = __version__
 # As provide as a tuple, with each value as it's own entry.
 # ie. "1.0" -> `("1", "0")`

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,11 +15,19 @@ import numpy as np
 import pkg_resources
 import pytest
 import tempfile
+from typing import Any, Tuple
 
 from reaction_plane_fit import base
 from reaction_plane_fit import example
 from reaction_plane_fit import plot
 from reaction_plane_fit import three_orientations
+
+# Typing helpers
+# This is a tuple of the matplotlib figure and axes. However, we only specify Any here
+# because we don't want an explicit package dependency on matplotlib.
+Axes = Any
+Figure = Any
+DrawResult = Tuple[Figure, Axes]
 
 @pytest.fixture
 def setup_integration_tests(logging_mixin) -> str:
@@ -89,7 +97,7 @@ def compare_fit_result_to_expected(fit_result: base.FitResult, expected_fit_resu
 
 @pytest.mark.slow
 @pytest.mark.mpl_image_compare(tolerance = 5)
-def test_inclusive_signal_fit(setup_integration_tests):
+def test_inclusive_signal_fit(setup_integration_tests) -> Figure:
     """ Integration test for the inclusive signal fit.
 
     This uses the sample data in the ``testFiles`` directory.
@@ -289,7 +297,7 @@ def test_inclusive_signal_fit(setup_integration_tests):
     # Run the fit
     # NOTE: The user_arguments are the same as the defaults to ensure that they don't change the fit, but we specify
     #       one to test the logic of how they are set.
-    rp_fit, data = example.run_inclusive_signal_fit(
+    rp_fit, data, _ = example.run_inclusive_signal_fit(
         input_filename = sample_data_filename,
         user_arguments = {"v2_t": 0.02},
     )
@@ -303,12 +311,12 @@ def test_inclusive_signal_fit(setup_integration_tests):
     # Draw and check the resulting image. It is checked by returning the figure.
     # We skip the residual plot because it is hard to compare multiple images from in the same test.
     # Instead, we get around this by comparing the residual in test_background_fit(...)
-    fig, ax = plot.draw_fit(rp_fit = rp_fit, data = data, filename = None)
+    fig, ax = plot.draw_fit(rp_fit = rp_fit, data = data, filename = "")
     return fig
 
 @pytest.mark.slow
 @pytest.mark.mpl_image_compare(tolerance = 5)
-def test_background_fit(setup_integration_tests):
+def test_background_fit(setup_integration_tests) -> Figure:
     """ Integration test for the background fit.
 
     This uses the sample data in the ``testFiles`` directory.
@@ -427,7 +435,7 @@ def test_background_fit(setup_integration_tests):
     # Run the fit
     # NOTE: The user_arguments are the same as the defaults to ensure that they don't change the fit, but we specify
     #       one to test the logic of how they are set.
-    rp_fit, data = example.run_background_fit(
+    rp_fit, data, _ = example.run_background_fit(
         input_filename = sample_data_filename,
         user_arguments = {"v2_t": 0.02},
     )
@@ -443,7 +451,7 @@ def test_background_fit(setup_integration_tests):
     # Draw and check the resulting image. It is checked by returning the figure.
     # We skip the fit plot because it is hard to compare multiple images from in the same test.
     # Instead, we get around this by comparing the fit in test_inclusive_signal_fit(...)
-    fig, ax = plot.draw_residual(rp_fit = rp_fit, data = data, filename = None)
+    fig, ax = plot.draw_residual(rp_fit = rp_fit, data = data, filename = "")
     return fig
 
 @pytest.mark.slow
@@ -461,7 +469,7 @@ def test_write_and_read_result_in_class(logging_mixin, setup_integration_tests, 
     # Setup
     sample_data_filename = setup_integration_tests
 
-    expected_rp_fit, data = example_module_func(
+    expected_rp_fit, data, _ = example_module_func(
         input_filename = sample_data_filename,
         user_arguments = {"v2_t": 0.02},
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -85,7 +85,7 @@ def compare_fit_result_to_expected(fit_result: base.FitResult, expected_fit_resu
         np.testing.assert_allclose(
             correlation,
             list(expected_fit_result.correlation_matrix.values()),
-            atol = 1e-4, rtol = 0,
+            atol = 5e-4, rtol = 0,
         )
     # Check that the correlation matrix diagonal is one as a sanity check
     correlation_diagonal = [expected_fit_result.correlation_matrix[(n, n)] for n in expected_fit_result.free_parameters]


### PR DESCRIPTION
Calculate the correlation matrix from the covariance matrix and make it available in the fit result. Note that testing this requires a minor interface change to make the underlying minuit object available (which may also generally be useful in advanced cases), but most users can and will it ignore